### PR TITLE
feat: handle special charater and fix send data custom function

### DIFF
--- a/dbstream/DBStream.py
+++ b/dbstream/DBStream.py
@@ -86,7 +86,7 @@ class DBStream:
             return None
         return result
 
-    def _send_data_custom(self, data, replace, **kwargs):
+    def _send_data_custom(self, data, replace, parse_dict=True, **kwargs):
         pass
 
     def _send(self, **args):
@@ -104,6 +104,7 @@ class DBStream:
                 .replace("-", "_")
                 .replace("@", "_")
                 .replace(":", "_")
+                .replace("/", "_")
             for c in data["columns_name"]]
         counter = {}
         new_columns_name = []


### PR DESCRIPTION
* Replace slash with underscore in table names
* Add parse dict to send data custom arguments to fix the function that currently fails there in the send_data function

````
        data_copy2 = copy.deepcopy(data_copy)
        if self._send_data_custom(data_copy, replace, **kwargs) != 0:
            url = os.environ.get("MONITORING_URL")
            if url:
                table_schema_name = data_copy2["table_name"].split(".")
````